### PR TITLE
Change jGrass link to github page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The [reMarkable](https://www.remarkable.com) is a paper tablet for those who pre
 ## Device Tools
 - [Funcky reMarkable Exporter](https://github.com/simonbaudart/Funcky.Remarkable.Exporter) - Export notes from a reMarkable Tablet to File System and External Services.
 - [instapaper-as-pdf-to-reMarkable](https://github.com/fabianmu/instapaper-as-pdf-to-remarkable) - Export Instapaper-Articles to PDF and send them to a connected rM tablet.
-- [jGrass](https://github.com/moovida/remarkable-hyutilities) - A GUI written in java to backup your device, upload templates and modify spash screens.
+- [reMarkable-hyutilities](https://github.com/moovida/remarkable-hyutilities) - A GUI written in java to backup your device, upload templates and modify spash screens.
 - [reHackable/maxio](https://github.com/reHackable/maxio) - Companion daemon for the reMarkable paper tablet.
 - [reHackable/scripts](https://github.com/reHackable/scripts) - A set of bash scripts that may enhance your reMarkable experience.
 - [reMarkable-assistant](https://github.com/richeymichael/remarkable-assistant) - Manage templates, splash screens, and settings on your reMarkable tablet.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The [reMarkable](https://www.remarkable.com) is a paper tablet for those who pre
 ## Device Tools
 - [Funcky reMarkable Exporter](https://github.com/simonbaudart/Funcky.Remarkable.Exporter) - Export notes from a reMarkable Tablet to File System and External Services.
 - [instapaper-as-pdf-to-reMarkable](https://github.com/fabianmu/instapaper-as-pdf-to-remarkable) - Export Instapaper-Articles to PDF and send them to a connected rM tablet.
-- [jGrass](http://jgrasstechtips.blogspot.com/2018/07/do-you-own-remarkable-this-could-help.html) - A GUI written in java to backup your device, upload templates and modify spash screens.
+- [jGrass](https://github.com/moovida/remarkable-hyutilities) - A GUI written in java to backup your device, upload templates and modify spash screens.
 - [reHackable/maxio](https://github.com/reHackable/maxio) - Companion daemon for the reMarkable paper tablet.
 - [reHackable/scripts](https://github.com/reHackable/scripts) - A set of bash scripts that may enhance your reMarkable experience.
 - [reMarkable-assistant](https://github.com/richeymichael/remarkable-assistant) - Manage templates, splash screens, and settings on your reMarkable tablet.


### PR DESCRIPTION
Makes more sense to link ~jGrass~ reMarkable-hyutilities source code / github page.

Would love to know what @moovida thinks about the change. 