### PR TITLE
Add CUPS printing entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The [reMarkable](https://www.remarkable.com) is a paper tablet for those who pre
 - [plato](https://github.com/darvin/plato) - Plato reader port. Supports pdfs, epubs, many other formats.
 
 ## Cloud Tools
+- [CUPS Printing](https://ofosos.org/2018/10/22/printing-to-remarkable-cloud-from-cups/) - Script to print directly to reMarkable Cloud from CUPS using rMAPI.
 - [reMarkable Web App](https://remarkableweb.app) - Web App for interfacing with the reMarkable paper tablet.
 - [rM-sync](https://github.com/simonschllng/rm-sync) - Sync script for reMarkable paper tablet.
 - [zotero-reMarkable](https://github.com/michaelmior/zotero-remarkable) - Script to sync PDFs from the [Zotero](https://www.zotero.org/) reference manager.


### PR DESCRIPTION
Add en entry about a way to print to reMarkable Cloud from CUPS, links to code in the article.