### PR TITLE
Add arxiv2remarkable to device tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The [reMarkable](https://www.remarkable.com) is a paper tablet for those who pre
 - [zotero-reMarkable](https://github.com/michaelmior/zotero-remarkable) - Script to sync PDFs from the [Zotero](https://www.zotero.org/) reference manager.
 
 ## Device Tools
+- [arxiv2remarkable](https://github.com/GjjvdBurg/arxiv2remarkable) - Download an arXiv paper, crop it, and send it to the reMarkable.
 - [Funcky reMarkable Exporter](https://github.com/simonbaudart/Funcky.Remarkable.Exporter) - Export notes from a reMarkable Tablet to File System and External Services.
 - [instapaper-as-pdf-to-reMarkable](https://github.com/fabianmu/instapaper-as-pdf-to-remarkable) - Export Instapaper-Articles to PDF and send them to a connected rM tablet.
 - [morningpaper2remarkable](https://github.com/jessfraz/morningpaper2remarkable) - A bot to sync the morning paper to a remarkable tablet.


### PR DESCRIPTION
I created a script to send an arXiv paper to the reMarkable with a single command. The script downloads the paper, crops the pdf, and sends it to the reMarkable using rMapi. Thought it might be useful to add to this list.