### PR TITLE
Update description of paper2remarkable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ The [reMarkable](https://www.remarkable.com) is a paper tablet for those who pre
 - [zotero-reMarkable](https://github.com/michaelmior/zotero-remarkable) - Script to sync PDFs from the [Zotero](https://www.zotero.org/) reference manager.
 
 ## Device Tools
-- [arxiv2reMarkable](https://github.com/GjjvdBurg/arxiv2remarkable) - Download an arXiv paper, crop it, and send it to the reMarkable.
+
 - [Funcky reMarkable Exporter](https://github.com/simonbaudart/Funcky.Remarkable.Exporter) - Export notes from a reMarkable Tablet to File System and External Services.
 - [instapaper-as-pdf-to-reMarkable](https://github.com/fabianmu/instapaper-as-pdf-to-remarkable) - Export Instapaper-Articles to PDF and send them to a connected rM tablet.
 - [morningpaper2reMarkable](https://github.com/jessfraz/morningpaper2remarkable) - A bot to sync the morning paper to a remarkable tablet.
+- [paper2reMarkable](https://github.com/GjjvdBurg/paper2remarkable) - Download an academic paper or HTML article, crop it, and send it to the reMarkable with a single command.
 - [reHackable/maxio](https://github.com/reHackable/maxio) - Companion daemon for the reMarkable paper tablet.
 - [reHackable/scripts](https://github.com/reHackable/scripts) - A set of bash scripts that may enhance your reMarkable experience.
 - [reMarkable-assistant](https://github.com/richeymichael/remarkable-assistant) - Manage templates, splash screens, and settings on your reMarkable tablet.


### PR DESCRIPTION
A while ago I added the arxiv2remarkable script I wrote to this list. That script has since grown into a Python package for sending documents quickly to the remarkable, including academic papers from various sources as well as HTML articles. This description hopefully better captures what the package does.