### PR TITLE
pocket2rm can now be run on remarkable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The [reMarkable](https://www.remarkable.com) is a paper tablet for those who pre
 - [reMarkable keywriter](https://github.com/dps/remarkable-keywriter) - A distraction free keyboard notes app.
 - [reMarkable wikipedia](https://github.com/dps/remarkable-wikipedia) - Offline wikipedia reader for reMarkable.
 - [rmvncclient](https://github.com/matteodelabre/rmvncclient) - VNC client for the reMarkable tablet allowing you to turn the device into an external screen.
+- [pocket2rm](https://github.com/glidergeek/pocket2rm) - Synchronize articles from read-later platform pocket in PDF and epub
 
 ## Cloud Tools
 - [CUPS Printing](https://ofosos.org/2018/10/22/printing-to-remarkable-cloud-from-cups/) - Script to print directly to reMarkable Cloud from CUPS using rMAPI.
@@ -47,7 +48,6 @@ The [reMarkable](https://www.remarkable.com) is a paper tablet for those who pre
 - [instapaper-as-pdf-to-reMarkable](https://github.com/fabianmu/instapaper-as-pdf-to-remarkable) - Export Instapaper-Articles to PDF and send them to a connected rM tablet.
 - [morningpaper2reMarkable](https://github.com/jessfraz/morningpaper2remarkable) - A bot to sync the morning paper to a remarkable tablet.
 - [paper2reMarkable](https://github.com/GjjvdBurg/paper2remarkable) - Download an academic paper or HTML article, crop it, and send it to the reMarkable with a single command.
-- [pocket2rm](https://github.com/glidergeek/pocket2rm) - Download articles from read-later platform pocket in PDF and epub, ready for import on reMarkable.
 - [reHackable/maxio](https://github.com/reHackable/maxio) - Companion daemon for the reMarkable paper tablet.
 - [reHackable/scripts](https://github.com/reHackable/scripts) - A set of bash scripts that may enhance your reMarkable experience.
 - [RemaPy](https://github.com/peerdavid/remapy) - GUI to browse, download/upload files and backup the tablet (also on Linux) using the cloud.


### PR DESCRIPTION
previously it had to be run on your pc and synced with the remarkable program. now it runs on the reMarkable directly. text is updated to reflect this and moved to other category