### PR TITLE
[add line] Add crazy cow link and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The [reMarkable](https://www.remarkable.com) is a paper tablet for those who pre
 - [sync_zotero_remarkable](https://github.com/danijoo/sync_zotero_remarkable) - Sync PDFs from Zotero to Remarkable.
 
 ## Device Tools
-
+- [Crazy Cow](https://github.com/machinelevel/sp425-crazy-cow) - Typewriter input from USB keyboard directly into reMarkable interface.
 - [Funcky reMarkable Exporter](https://github.com/simonbaudart/Funcky.Remarkable.Exporter) - Export notes from a reMarkable Tablet to File System and External Services.
 - [instapaper-as-pdf-to-reMarkable](https://github.com/fabianmu/instapaper-as-pdf-to-remarkable) - Export Instapaper-Articles to PDF and send them to a connected rM tablet.
 - [morningpaper2reMarkable](https://github.com/jessfraz/morningpaper2remarkable) - A bot to sync the morning paper to a remarkable tablet.


### PR DESCRIPTION
Add link to [Crazy Cow](https://github.com/machinelevel/sp425-crazy-cow/blob/master/README.md), which provides typewriter input from USB keyboard directly into reMarkable interface.