### PR TITLE
The missing book store for remarkable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Take special care if you are using a reMarkable 2:
 - [plato](https://github.com/darvin/plato) - Plato reader port. Supports pdfs, epubs, many other formats.
 - [reMarkable keywriter](https://github.com/dps/remarkable-keywriter) - A distraction free keyboard notes app.
 - [reMarkable wikipedia](https://github.com/dps/remarkable-wikipedia) - Offline wikipedia reader for reMarkable.
+- [Rebook](https://github.com/fsniper/ReBook) - The missing book store for reMarkable.
 
 ### Games
 


### PR DESCRIPTION
I started working on an ebook downloader for reMarkable. 

It's still in the early stages, but usable. It uses rmkit,okp for ui and golang for the backend. Currently only standardebooks.org site is supported.