### PR TITLE
Add rm-pdf-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ This function may not do what you are expecting. While it resets all user data, 
 - [reMarkable-Sink](http://github.com/hmenzagh/reMarkable-Sink) - Turn a folder into a wormhole to your reMarkable.
 - [reMarkable_syncthing](http://github.com/evidlo/remarkable_syncthing) - Syncthing on reMarkable.
 - [remarkable-zapier](https://github.com/artes-dev/remarkable-zapier) - Zapier Integration for reMarkable Cloud
+- [rm-pdf-tools](https://github.com/skius/rm-pdf-tools) - Service that allows users to insert and delete pages from annotated PDFs on the device.
 - [rM-sync](https://github.com/simonschllng/rm-sync) - Sync script for reMarkable paper tablet.
 - [RMfuse](https://github.com/rschroll/rmfuse) - FUSE filesystem for the reMarkable Cloud.
 - [sync_zotero_remarkable](https://github.com/danijoo/sync_zotero_remarkable) - Sync PDFs from Zotero to reMarkable.


### PR DESCRIPTION
Add [rm-pdf-tools](https://github.com/skius/rm-pdf-tools) to the "Cloud Tools" section. It adds rudimentary (for now) PDF-editing capabilities to the reMarkable tablet using the reMarkable Cloud.