### PR TITLE
Add reCalendar calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ This function may not do what you are expecting. While it resets all user data, 
 
 ## Custom Templates
 
+- [reCalendar](https://github.com/klimeryk/recalendar) - Highly customizable calendar optimized for reMarkable.
 - [reMarkable-bujo](https://github.com/vonneudeck/remarkable-bujo) - "Bullet Journal" templates.
 - [remarkable-engineering](https://gitlab.com/asciiphil/remarkable-engineering) - Engineering-style grid templates.
 - [reMarkable-gtd-templates](https://github.com/BartKeulen/remarkable-gtd-templates) - "Getting Things Done" templates.


### PR DESCRIPTION
Adds [reCalendar](https://github.com/klimeryk/recalendar), a highly customizable calendar optimized for reMarkable.

See also [the discussion on reddit](https://www.reddit.com/r/RemarkableTablet/comments/odpl07/recalendar_opensource_highly_customizable/). I got some great feedback and I feel the project is worthy of inclusion on this list 🙇 

<img width="692" alt="Screenshot 2021-11-21 at 20 47 37" src="https://user-images.githubusercontent.com/3392497/142778410-68fd5164-c2e9-4ad9-8dc2-40e1224064e4.png">
