### PR TITLE
Add recalendar.me online calendar generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ This function may not do what you are expecting. While it resets all user data, 
 
 ## Custom Templates
 
-- [reCalendar](https://github.com/klimeryk/recalendar) - Highly customizable calendar optimized for reMarkable.
+- [ReCalendar.me](https://recalendar.me/) - Highly customizable online calendar generator optimized for reMarkable.
+- [ReCalendar](https://github.com/klimeryk/recalendar) - Highly customizable calendar generator in PHP optimized for reMarkable.
 - [reMarkable-bujo](https://github.com/vonneudeck/remarkable-bujo) - "Bullet Journal" templates.
 - [remarkable-engineering](https://gitlab.com/asciiphil/remarkable-engineering) - Engineering-style grid templates.
 - [reMarkable-gtd-templates](https://github.com/BartKeulen/remarkable-gtd-templates) - "Getting Things Done" templates.


### PR DESCRIPTION
Hi! This is sort of related to my previous PR: https://github.com/reHackable/awesome-reMarkable/pull/145

But https://recalendar.me/ (source code here: https://github.com/klimeryk/recalendar.js/) is a complete rewrite of that project. This time as a modern, easy to use webapp. No need to install anything, everything is done in browser (including PDF generation). Plus, lots of other [features](https://recalendar.me/features). Hope you like it!

PS: I've adjusted the captialization to `ReCalendar`, as originally I got confused by the contributing guidelines. I thought the `reMarkable` rule applied to everything, but I now see there's a clear distinction that it does _not_ apply to project/repos. Since I've been using `ReCalendar` everywhere and not `reCalendar`, I wanted to go with that. Though, now that you've pointed it out, I see that it's indeed `reMarkable` and I'm not sure how I ended up on `ReCalendar` 😅 