### PR TITLE
Add another warning about the SSH password

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The [reMarkable](https://www.remarkable.com) is a paper tablet for those who pre
 
 No project here is affiliated or endorsed by [reMarkable AS](https://github.com/remarkable). If you modify your device official support might refuse to help you. 
 
-### ⚠️ Write down your SSH password ⚠️
+### Write down your SSH password
 
 **WARNING!!**
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ The [reMarkable](https://www.remarkable.com) is a paper tablet for those who pre
 
 No project here is affiliated or endorsed by [reMarkable AS](https://github.com/remarkable). If you modify your device official support might refuse to help you. 
 
+### ⚠️ Write down your SSH password ⚠️
+
+**WARNING!!**
+
+**Make sure you have saved your SSH password somewhere secure** when installing Toltec and before installing any package. You can find the SSH password in your settings: `Settings > Help > Copyrights and licenses > General information (scroll down)`.
+
+If you don't know how to do this, you can find the procedure on the (wiki)[https://remarkablewiki.com/tech/ssh#passwordless_login_with_ssh_keys].
+
+Failure to do so could mean **a bricked and worthless device** and would require a hardware plug to recover from the bricked state. You have been warned!
+
 ### Factory reset may brick your device
 
 This function may not do what you are expecting. While it resets all user data, it will not restore the device to the original factory condition. It will reset your SSH password and remove all SSH keys, which may make it impossible to connect to your device if it is malfunctioning.


### PR DESCRIPTION
I know it's already in the Toltec setup instructions, but I think another warning here would be good for people that tend to rush through things. Thanks!