### PR TITLE
Move ReCalendar to "Template Builders"

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,6 @@ This function may not do what you are expecting. While it resets all user data, 
 ## Custom Templates
 
 - [latex-yearly-planner](https://github.com/kudrykv/latex-yearly-planner) - PDF planner designed for e-ink devices.
-- [ReCalendar.me](https://recalendar.me/) - Highly customizable online calendar generator optimized for reMarkable.
-- [ReCalendar](https://github.com/klimeryk/recalendar) - Highly customizable calendar generator in PHP optimized for reMarkable.
 - [reMarkable-bujo](https://github.com/vonneudeck/remarkable-bujo) - "Bullet Journal" templates.
 - [remarkable-engineering](https://gitlab.com/asciiphil/remarkable-engineering) - Engineering-style grid templates.
 - [reMarkable-gtd-templates](https://github.com/BartKeulen/remarkable-gtd-templates) - "Getting Things Done" templates.
@@ -195,5 +193,7 @@ This function may not do what you are expecting. While it resets all user data, 
 ### Template Builders
 
 - [NoTeTo](https://noteto.needleinthehay.de/) - Design templates by drag and drop components
+- [ReCalendar.me](https://recalendar.me/) - Highly customizable online calendar generator optimized for reMarkable.
+- [ReCalendar](https://github.com/klimeryk/recalendar) - Highly customizable calendar generator in PHP optimized for reMarkable.
 - [Remarkable Grid Template Generator](https://xosh.org/remarkable-grid-template/) - Generate pixel perfect line grid and dotted grid templates
 - [reMarkable Template Builder](https://templarian.github.io/remarkable/) - Generate Isometric and Grid templates of all sizes


### PR DESCRIPTION
This is suggested as ReCalendar is a template builder rather than a premade template.