### PR TITLE
Add rm-pySAS

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ This function may not do what you are expecting. While it resets all user data, 
 - [remt](https://gitlab.com/wrobell/remt) - reMarkable tablet command-line tools.
 - [reSnap](https://github.com/cloudsftp/reSnap) - Take snapshots of your reMarkable screen over SSH.
 - [rM-dl-annotated](https://github.com/jmptable/rm-dl-annotated) - Export annotated PDFs from reMarkable tablets.
+- [rm-pySAS](https://github.com/tenJirka/rm-pySAS) - Python wrapper for [simple](https://rmkit.dev/apps/sas).
 - [rMsync](https://github.com/lschwetlick/rMsync) - Synchronisation script with a local dedicated "library" folder.
 - [rmTabletDriver](https://github.com/LinusCDE/rmTabletDriver) - Application that allows you to simulate/clone rM input on your computer.
 - [rmWacomToMouse](https://github.com/LinusCDE/rmWacomToMouse) - Use the wacom pen as a mouse to draw on your pc.


### PR DESCRIPTION
[rm-pySAS](https://github.com/tenJirka/rm-pySAS) is python wrapper around [simple](https://rmkit.dev/apps/sas).
It can be used to create simple applications for reMarkable in Python.