### PR TITLE
Mark reCatchable as unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ This function may not do what you are expecting. While it resets all user data, 
 
 - [CUPS Printing](https://ofosos.org/2018/10/22/printing-to-remarkable-cloud-from-cups/) - Script to print directly to reMarkable Cloud from CUPS using rMAPI.
 - [mendeley-rMsync](https://github.com/anilkyelam/mendeley-rMsync) - Script to sync PDFs (with annotations) from/to a [Mendeley](https://www.mendeley.com/) folder.
-- [Papeer](https://github.com/lapwat/papeer) - Golang re-write of [reCatchable](https://github.com/lapwat/reCatchable); turn website into ebooks and upload to reMarkable.
 - (Unmaintained) [reCatchable](https://github.com/lapwat/reCatchable) - Turn websites into ebooks, upload them to reMarkable.
 - [reGitable](https://github.com/after-eight/regitable) - Backup your reMarkable with git and sync changes to a remote repository automatically.
 - [remarkable_simplenote](https://github.com/bgribble/remarkable_simplenote) - Sync simplenote notes to reMarkable (currently one-way)


### PR DESCRIPTION
Papeer is a golang version of reCatchable by the same author. reCatchable is archived on GitHub and will have no new updates.