### PR TITLE
Add reLuminate

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ See [remarkable.guide](https://remarkable.guide/tech/factory-reset.html) for mor
 ## Device Tools
 - [paginator](https://github.com/aflusche/paginator) - Physical foot pedal to turn pages on the device with no hands (e.g. for playing sheet music).
 - [ReCept](https://github.com/funkey/recept/) - Fix for the rM2 jagged line issue.
+- [reLuminate](https://github.com/unreMarkableLabs/reLuminate) - Enable enhanced screen brightness levels on the reMarkable Paper Pro.
 - [rM-signature-patch](https://github.com/Barabazs/rM-signature-patch) - Simple script to remove that pesky advert at the bottom of a mail originating from a reMarkable.
 - [remarvin](https://github.com/plan5/remarvin) - Profile and file encrytion manager that allows to manage notebooks for different users and to optionally protect the files with a password through gocryptfs-based encryption (device only).
 - [Signature-rM](https://github.com/rM-self-serve/signature-rM) - Remove the signature from the bottom of emails sent from the device.


### PR DESCRIPTION
**reLuminate** unlocks enhanced brightness levels for the reMarkable Paper Pro, giving you more control over your screen’s reading light. Say goodbye to the factory’s lackluster brightness settings!

- **Enhanced Brightness Levels** – Adjust the screen lighting beyond the default limitations.
- **Persists Across Reboots** – Access to enhanced brightness settings stay in place even after restarting your device.
- **Simple Installation** – A simple install script takes care of the setup, so you don't have to.