### PR TITLE
Update remarks repo to fork that is still active

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ See [remarkable.guide](https://remarkable.guide/tech/factory-reset.html) for mor
 - [RemarkableLamyEraser](https://github.com/isaacwisdom/RemarkableLamyEraser/) - Supports Lamy Al Star stylus button to erase or undo for reMarkable tablets.
 - [reMarkablePocket](https://github.com/nov1n/RemarkablePocket) - Synchronize articles from read-later platform Pocket in epub format.
 - [reMarkableSync](https://github.com/jamesf91/reMarkableSync) - A Microsoft OneNote addin for importing notebooks from reMarkable as text or images.
-- [remarks](https://github.com/lucasrla/remarks) - Extract highlights, scribbles, and annotations from PDFs. Export to Markdown, PNG, and SVG.
+- [remarks](https://github.com/Scrybbling-together/remarks) - Extract highlights, scribbles, and annotations from PDFs. Export to Markdown, PNG, and SVG.
 - [reMouseable](https://github.com/kevinconway/remouseable) - Use your reMarkable tablet as a mouse.
 - [remt](https://gitlab.com/wrobell/remt) - reMarkable tablet command-line tools.
 - [reSnap](https://github.com/cloudsftp/reSnap) - Take snapshots of your reMarkable screen over SSH.


### PR DESCRIPTION
[lucaslra's remarks repository](https://github.com/lucasrla/remarks) hasn't received an update in two years, and doesn't support the RMPP or recent versions of the reMarkable software.

I've updated it to [my fork of remarks](https://github.com/Scrybbling-together/remarks), which is actively maintained, and does support the RMPP and recent versions of the reMarkable software.