### PR TITLE
Remove unmaintained rmWebUI from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ See [remarkable.guide](https://remarkable.guide/tech/factory-reset.html) for mor
 - [rM2 Template Helper](https://www.freeremarkabletools.com/) Windows tool for template management, and to download community templates. 
 - [rMExplorer](https://github.com/bruot/pyrmexplorer/wiki) - GUI to browse, download/upload files and backup the tablet without using the cloud.
 - [rmUploader](https://github.com/lobre/rmuploader) - Simple web app to upload epub or pdf files to the reMarkable tablet via drag and drop.
-- (Unmaintained) [rmWebUI](https://github.com/polletfa/rmWebUI) - Simple web interface to the reMarkable&reg; cloud.
 - (Unmaintained) [Slithin](https://github.com/furesoft/Slithin) - Free Management Application for Windows/Linux/MacOS.
 
 ## Interface Customization


### PR DESCRIPTION
The application has been broken since the API change a few years back and the new official webapp from reMarkable now also allow to view the files, so I don't plan to revive the project. So please remove it from the list. I will also delete my repository.