### PR TITLE
Add Inkward to Cloud Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ See [remarkable.guide](https://remarkable.guide/tech/factory-reset.html) for mor
 - [AgentNews-RemarkableRSSReader](https://github.com/eksubin/AgentNews-RemarkableRSSReader) - An AI agent for processing RSS news feeds and sending them to reMarkable via Google Drive API.
 - [Aviary](https://github.com/rmitchellscott/aviary) - A webhook-driven document uploader for reMarkable Cloud and rmfakecloud, featuring a static UI and a Go backend. Optional integration for email via AWS SES.
 - [CUPS Printing](https://github.com/ofosos/scratch/tree/master/remarkable-cups) - Script to print directly to reMarkable Cloud from CUPS using rMAPI.
+- [Inkward](https://inkward.life) - Connects your reMarkable Cloud and turns your handwritten entries into a calm daily, weekly, and monthly reflection of your own words; private, EU-hosted, GDPR-first.
 - [mendeley-rMsync](https://github.com/anilkyelam/mendeley-rMsync) - Script to sync PDFs (with annotations) from/to a [Mendeley](https://www.mendeley.com/) folder.
 - [Moss](https://github.com/RedTTGMoss/moss-desktop) - An app for working with your documents in the reMarkable/rmFakeCloud cloud
 - [pdf2remarkable](https://github.com/teticio/pdf2remarkable) - Script to upload PDFs to the reMarkable Cloud.


### PR DESCRIPTION
Adds [Inkward](https://inkward.life) under **Cloud Tools** (placed alphabetically).

Inkward connects your reMarkable Cloud and turns your handwritten entries into a calm daily, weekly, and monthly reflection of your own words — it reflects, it doesn't advise or score. Independent German product, EU-hosted, GDPR-first.