### PR TITLE
Add reCalibre-Driver to the README.md list

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ See [remarkable.guide](https://remarkable.guide/tech/factory-reset.html) for mor
 - [Parabola-rM](http://www.davisr.me/projects/parabola-rm/) - A Desktop GNU/Linux-libre replacement OS with fast partial refreshing and USB OTG.
 - [pdf2rmnotebook](https://github.com/JCN-9000/pdf2rmnotebook) - Creates a reMarkable Notebook from multiple PDF files.
 - [pocket2rm](https://github.com/glidergeek/pocket2rm) - Synchronize articles from read-later platform pocket in PDF and epub.
+- [reCalibre-Driver](https://github.com/zer0trip/reCalibre) - A maintained Calibre plugin for syncing books to a reMarkable, via KOReader or the native UI.
 - [reHackable/maxio](https://github.com/reHackable/maxio) - Companion daemon for the reMarkable paper tablet.
 - [remailable](https://github.com/j6k4m8/remailable) - Email PDFs directly to your reMarkable. ([Free publicly-hosted version available](https://remailable.getneutrality.org/)).
 - [reMarkable CLI tooling](https://github.com/cherti/remarkable-cli-tooling) - CLI-tooling to sync documents to a reMarkable, to clean deleted files etc. without needing cloud access

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ See [remarkable.guide](https://remarkable.guide/tech/factory-reset.html) for mor
 - [Parabola-rM](http://www.davisr.me/projects/parabola-rm/) - A Desktop GNU/Linux-libre replacement OS with fast partial refreshing and USB OTG.
 - [pdf2rmnotebook](https://github.com/JCN-9000/pdf2rmnotebook) - Creates a reMarkable Notebook from multiple PDF files.
 - [pocket2rm](https://github.com/glidergeek/pocket2rm) - Synchronize articles from read-later platform pocket in PDF and epub.
-- [reCalibre-Driver](https://github.com/zer0trip/reCalibre) - A maintained Calibre plugin for syncing books to a reMarkable, via KOReader or the native UI.
+- [reCalibre-Driver](https://github.com/zer0trip/reCalibre) - A Calibre plugin for syncing books to a reMarkable, via KOReader or the native UI.
 - [reHackable/maxio](https://github.com/reHackable/maxio) - Companion daemon for the reMarkable paper tablet.
 - [remailable](https://github.com/j6k4m8/remailable) - Email PDFs directly to your reMarkable. ([Free publicly-hosted version available](https://remailable.getneutrality.org/)).
 - [reMarkable CLI tooling](https://github.com/cherti/remarkable-cli-tooling) - CLI-tooling to sync documents to a reMarkable, to clean deleted files etc. without needing cloud access


### PR DESCRIPTION
Adds reCalibre-Driver (https://github.com/zer0trip/reCalibre) to the Other section, alphabetically between pocket2rm and reHackable/maxio.

It's a maintained Calibre device plugin for syncing books to a reMarkable, either as plain files for KOReader or into the native reMarkable document format. It's a fork of the (Unmaintained) Calibre-Remarkable-Device-Driver-Plugin already listed here, updated to work with current Calibre/OS versions and with KOReader support added.